### PR TITLE
Mark mounted Git repository as safe for Terragrunt in-built functions…

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -155,6 +155,10 @@ function installTerragrunt {
 }
 
 function main {
+  # In Docker, Github actions mounts the Git repository in a way that breaks Terragrunt detection of the Git root
+  # Mark the mounted workspace as safe so Terragrunt built-in functions can detect Git root without problems
+  git config --global --add safe.directory $GITHUB_WORKSPACE
+
   # Source the other files to gain access to their functions
   echo "Loading terragrunt script modules"
   scriptDir=$(dirname ${0})


### PR DESCRIPTION
… to work correctly

# Context
The docker setup breaks Terragrunt functions like `get_path_from_repo_root`, etc. This is purely due to the way the repo is mounted  - I think the repo in the Docker image does not belong to the user running in Docker. This is mostly a non-issue but causes Terragrunt to break. 

Marking the workspace directory as "safe"